### PR TITLE
Add Wordle ranking feature with statistics tracking

### DIFF
--- a/src/main/java/me/owlsleep/owlab/dto/response/WordleRankingDto.java
+++ b/src/main/java/me/owlsleep/owlab/dto/response/WordleRankingDto.java
@@ -1,0 +1,15 @@
+package me.owlsleep.owlab.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class WordleRankingDto {
+    private final Integer rank;
+    private final String displayName;
+    private final long successCount;
+    private final long totalGames;
+    private final double winRate;
+    private final boolean mine;
+}

--- a/src/main/java/me/owlsleep/owlab/entity/WordleStatistic.java
+++ b/src/main/java/me/owlsleep/owlab/entity/WordleStatistic.java
@@ -1,0 +1,28 @@
+package me.owlsleep.owlab.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(name = "wordle_statistics")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class WordleStatistic {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false, unique = true)
+    private User user;
+
+    @Column(nullable = false)
+    private long totalGames;
+
+    @Column(nullable = false)
+    private long successCount;
+}

--- a/src/main/java/me/owlsleep/owlab/repository/WordleStatisticRepository.java
+++ b/src/main/java/me/owlsleep/owlab/repository/WordleStatisticRepository.java
@@ -1,0 +1,17 @@
+package me.owlsleep.owlab.repository;
+
+import me.owlsleep.owlab.entity.User;
+import me.owlsleep.owlab.entity.WordleStatistic;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface WordleStatisticRepository extends JpaRepository<WordleStatistic, Long> {
+
+    Optional<WordleStatistic> findByUser(User user);
+
+    List<WordleStatistic> findTop10ByOrderBySuccessCountDescTotalGamesAscIdAsc();
+
+    List<WordleStatistic> findAllByOrderBySuccessCountDescTotalGamesAscIdAsc();
+}

--- a/src/main/java/me/owlsleep/owlab/service/WordleStatisticService.java
+++ b/src/main/java/me/owlsleep/owlab/service/WordleStatisticService.java
@@ -1,0 +1,137 @@
+package me.owlsleep.owlab.service;
+
+import lombok.RequiredArgsConstructor;
+import me.owlsleep.owlab.dto.response.WordleRankingDto;
+import me.owlsleep.owlab.entity.User;
+import me.owlsleep.owlab.entity.WordleStatistic;
+import me.owlsleep.owlab.repository.WordleStatisticRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class WordleStatisticService {
+
+    private final WordleStatisticRepository wordleStatisticRepository;
+
+    @Transactional
+    public void recordGameResult(User user, boolean success) {
+        if (user == null) {
+            return;
+        }
+        WordleStatistic statistic = wordleStatisticRepository.findByUser(user)
+                .orElseGet(() -> WordleStatistic.builder()
+                        .user(user)
+                        .totalGames(0L)
+                        .successCount(0L)
+                        .build());
+
+        statistic.setTotalGames(statistic.getTotalGames() + 1);
+        if (success) {
+            statistic.setSuccessCount(statistic.getSuccessCount() + 1);
+        }
+        wordleStatisticRepository.save(statistic);
+    }
+
+    public List<WordleRankingDto> getTopRankings(User currentUser) {
+        List<WordleStatistic> statistics = wordleStatisticRepository.findTop10ByOrderBySuccessCountDescTotalGamesAscIdAsc();
+        return toRankingDtos(statistics, currentUser);
+    }
+
+    public WordleRankingDto getRankingSnapshot(User user) {
+        if (user == null) {
+            return null;
+        }
+
+        Optional<WordleStatistic> optionalStatistic = wordleStatisticRepository.findByUser(user);
+        if (optionalStatistic.isEmpty()) {
+            return createEmptyRanking(user);
+        }
+
+        WordleStatistic statistic = optionalStatistic.get();
+        List<WordleStatistic> allStatistics = wordleStatisticRepository.findAllByOrderBySuccessCountDescTotalGamesAscIdAsc();
+        int rank = calculateRank(allStatistics, statistic);
+        return toRankingDto(statistic, rank, true);
+    }
+
+    private List<WordleRankingDto> toRankingDtos(List<WordleStatistic> statistics, User currentUser) {
+        List<WordleRankingDto> rankings = new ArrayList<>();
+        long previousSuccess = Long.MIN_VALUE;
+        long previousGames = Long.MIN_VALUE;
+        int currentRank = 0;
+
+        for (int i = 0; i < statistics.size(); i++) {
+            WordleStatistic statistic = statistics.get(i);
+            if (statistic.getSuccessCount() != previousSuccess || statistic.getTotalGames() != previousGames) {
+                currentRank = i + 1;
+                previousSuccess = statistic.getSuccessCount();
+                previousGames = statistic.getTotalGames();
+            }
+            boolean mine = currentUser != null && statistic.getUser().getId().equals(currentUser.getId());
+            rankings.add(toRankingDto(statistic, currentRank, mine));
+        }
+
+        return rankings;
+    }
+
+    private int calculateRank(List<WordleStatistic> statistics, WordleStatistic target) {
+        long previousSuccess = Long.MIN_VALUE;
+        long previousGames = Long.MIN_VALUE;
+        int currentRank = 0;
+
+        for (int i = 0; i < statistics.size(); i++) {
+            WordleStatistic statistic = statistics.get(i);
+            if (statistic.getSuccessCount() != previousSuccess || statistic.getTotalGames() != previousGames) {
+                currentRank = i + 1;
+                previousSuccess = statistic.getSuccessCount();
+                previousGames = statistic.getTotalGames();
+            }
+            if (statistic.getId().equals(target.getId())) {
+                return currentRank;
+            }
+        }
+        return statistics.size() + 1;
+    }
+
+    private WordleRankingDto toRankingDto(WordleStatistic statistic, Integer rank, boolean mine) {
+        return WordleRankingDto.builder()
+                .rank(rank)
+                .displayName(resolveDisplayName(statistic.getUser()))
+                .successCount(statistic.getSuccessCount())
+                .totalGames(statistic.getTotalGames())
+                .winRate(calculateWinRate(statistic))
+                .mine(mine)
+                .build();
+    }
+
+    private WordleRankingDto createEmptyRanking(User user) {
+        return WordleRankingDto.builder()
+                .rank(null)
+                .displayName(resolveDisplayName(user))
+                .successCount(0L)
+                .totalGames(0L)
+                .winRate(0.0)
+                .mine(true)
+                .build();
+    }
+
+    private double calculateWinRate(WordleStatistic statistic) {
+        if (statistic.getTotalGames() == 0) {
+            return 0.0;
+        }
+        double rate = (double) statistic.getSuccessCount() / statistic.getTotalGames() * 100.0;
+        return Math.round(rate * 10.0) / 10.0;
+    }
+
+    private String resolveDisplayName(User user) {
+        if (user.getName() != null && !user.getName().isBlank()) {
+            return user.getName();
+        }
+        return user.getUsername();
+    }
+}

--- a/src/main/resources/static/css/wordle-ranking.css
+++ b/src/main/resources/static/css/wordle-ranking.css
@@ -1,0 +1,152 @@
+.ranking-section {
+    display: flex;
+    flex-direction: column;
+    gap: 2rem;
+}
+
+.ranking-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 1rem;
+}
+
+.ranking-header h2 {
+    margin-bottom: 0.3rem;
+}
+
+.ranking-subtitle {
+    color: #666;
+    font-size: 0.95rem;
+}
+
+.ranking-back-link {
+    padding: 10px 20px;
+    border-radius: 20px;
+    background-color: var(--secondary-color);
+    color: #fff;
+    text-decoration: none;
+    font-weight: 600;
+    transition: background-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.ranking-back-link:hover {
+    background-color: var(--primary-color);
+    box-shadow: 0 3px 7px rgba(5, 5, 5, 0.3);
+}
+
+.ranking-table-wrapper {
+    background-color: #fff;
+    border-radius: 16px;
+    box-shadow: 0 8px 24px rgba(8, 15, 52, 0.08);
+    padding: 1.5rem;
+    overflow-x: auto;
+}
+
+.ranking-table {
+    width: 100%;
+    border-collapse: collapse;
+    min-width: 520px;
+}
+
+.ranking-table thead th {
+    text-align: center;
+    padding: 0.75rem;
+    font-size: 0.95rem;
+    color: #555;
+    border-bottom: 2px solid #f0f0f5;
+}
+
+.ranking-table tbody td {
+    text-align: center;
+    padding: 0.8rem 0.5rem;
+    font-size: 1rem;
+    border-bottom: 1px solid #f2f2f7;
+}
+
+.ranking-table tbody tr:nth-child(even) {
+    background-color: #fafaff;
+}
+
+.ranking-table tbody tr.is-mine {
+    background-color: rgba(3, 33, 72, 0.08);
+    font-weight: 600;
+}
+
+.empty-row {
+    text-align: center;
+    padding: 1.5rem 0;
+    color: #777;
+    font-size: 0.95rem;
+}
+
+.my-ranking {
+    background-color: #fff;
+    border-radius: 16px;
+    box-shadow: 0 8px 24px rgba(8, 15, 52, 0.08);
+    padding: 1.5rem;
+}
+
+.my-ranking h3 {
+    margin-bottom: 1rem;
+}
+
+.my-ranking-card {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+    gap: 1rem;
+}
+
+.metric {
+    display: flex;
+    flex-direction: column;
+    gap: 0.4rem;
+    align-items: center;
+}
+
+.metric .label {
+    font-size: 0.9rem;
+    color: #666;
+}
+
+.metric .value {
+    font-size: 1.4rem;
+    font-weight: 600;
+}
+
+.my-ranking-guest {
+    text-align: center;
+}
+
+.login-link {
+    display: inline-block;
+    margin-top: 0.8rem;
+    padding: 8px 18px;
+    border-radius: 18px;
+    background-color: var(--secondary-color);
+    color: #fff;
+    text-decoration: none;
+    font-weight: 600;
+    transition: background-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.login-link:hover {
+    background-color: var(--primary-color);
+    box-shadow: 0 3px 7px rgba(5, 5, 5, 0.3);
+}
+
+@media (max-width: 768px) {
+    .ranking-header {
+        flex-direction: column;
+        align-items: flex-start;
+    }
+
+    .ranking-back-link {
+        align-self: stretch;
+        text-align: center;
+    }
+
+    .ranking-table {
+        min-width: 100%;
+    }
+}

--- a/src/main/resources/static/css/wordle.css
+++ b/src/main/resources/static/css/wordle.css
@@ -116,6 +116,14 @@
     transition: transform 0.1s;
 }
 
+.wordle-actions {
+    margin-top: 20px;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 12px;
+}
+
 .new-game-btn {
     background-color: var(--secondary-color);
     color: white;
@@ -133,5 +141,17 @@
 .new-game-btn:hover {
     background-color: var(--primary-color);
     box-shadow: 0 3px 7px rgba(5, 5, 5, 0.7);
+}
+
+.ranking-link {
+    color: var(--secondary-color);
+    font-weight: 600;
+    text-decoration: none;
+    transition: color 0.2s ease;
+}
+
+.ranking-link:hover {
+    color: var(--primary-color);
+    text-decoration: underline;
 }
 

--- a/src/main/resources/templates/wordle-ranking.html
+++ b/src/main/resources/templates/wordle-ranking.html
@@ -1,0 +1,75 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org"
+      xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
+      layout:decorate="~{layout}">
+
+<head>
+    <link rel="stylesheet" th:href="@{/css/wordle-ranking.css}" layout:fragment="styles">
+</head>
+
+<body>
+<section layout:fragment="content" class="ranking-section">
+    <div class="ranking-header">
+        <div>
+            <h2>워들 랭킹</h2>
+            <p class="ranking-subtitle">상위 10명의 누적 게임 클리어 기록을 확인하세요.</p>
+        </div>
+        <a class="ranking-back-link" th:href="@{/wordle}">워들 하러 가기</a>
+    </div>
+
+    <div class="ranking-table-wrapper">
+        <table class="ranking-table">
+            <thead>
+            <tr>
+                <th>순위</th>
+                <th>유저</th>
+                <th>성공수</th>
+                <th>시도수</th>
+                <th>승률</th>
+            </tr>
+            </thead>
+            <tbody>
+            <tr th:each="ranking : ${rankings}"
+                th:classappend="${ranking.mine} ? 'is-mine' : ''">
+                <td th:text="${ranking.rank != null ? ranking.rank : '-'}">1</td>
+                <td th:text="${ranking.displayName}">owlab</td>
+                <td th:text="${ranking.successCount}">5</td>
+                <td th:text="${ranking.totalGames}">7</td>
+                <td th:text="${ranking.totalGames == 0 ? '0%' : #numbers.formatDecimal(ranking.winRate, 1, 1) + '%'}">71.4%</td>
+            </tr>
+            <tr th:if="${#lists.isEmpty(rankings)}">
+                <td colspan="5" class="empty-row">아직 집계된 기록이 없습니다.</td>
+            </tr>
+            </tbody>
+        </table>
+    </div>
+
+    <div class="my-ranking" th:if="${session.loginUser != null}">
+        <h3>내 랭킹</h3>
+        <div class="my-ranking-card" th:if="${myRanking != null}">
+            <div class="metric">
+                <span class="label">순위</span>
+                <span class="value" th:text="${myRanking.rank != null ? myRanking.rank : '-'}">-</span>
+            </div>
+            <div class="metric">
+                <span class="label">성공수</span>
+                <span class="value" th:text="${myRanking.successCount}">0</span>
+            </div>
+            <div class="metric">
+                <span class="label">시도수</span>
+                <span class="value" th:text="${myRanking.totalGames}">0</span>
+            </div>
+            <div class="metric">
+                <span class="label">승률</span>
+                <span class="value" th:text="${myRanking.totalGames == 0 ? '0%' : #numbers.formatDecimal(myRanking.winRate, 1, 1) + '%'}">0%</span>
+            </div>
+        </div>
+    </div>
+
+    <div class="my-ranking my-ranking-guest" th:if="${session.loginUser == null}">
+        <p>로그인 후 나의 랭킹을 확인할 수 있습니다.</p>
+        <a class="login-link" th:href="@{/login}">로그인 하기</a>
+    </div>
+</section>
+</body>
+</html>

--- a/src/main/resources/templates/wordle.html
+++ b/src/main/resources/templates/wordle.html
@@ -58,8 +58,9 @@
     </div>
 
     <!-- 새 게임 시작 버튼 -->
-    <div style="text-align: center;">
+    <div class="wordle-actions">
         <button id="new-game-btn" class="new-game-btn">새 게임 시작하기</button>
+        <a class="ranking-link" th:href="@{/wordle/ranking}">랭킹 보러가기</a>
     </div>
 
 </section>


### PR DESCRIPTION
## Summary
- track per-user Wordle game completions and expose ranking data via a dedicated statistic service
- add a Wordle ranking page, styling, and entry point button from the game screen

## Testing
- `./gradlew test` *(fails: Java 17 toolchain is unavailable in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68d0e7e6297083289568ec18d48f451f