### PR TITLE
Use session-scoped state for Wordle games

### DIFF
--- a/src/main/java/me/owlsleep/owlab/controller/WordleController.java
+++ b/src/main/java/me/owlsleep/owlab/controller/WordleController.java
@@ -18,8 +18,9 @@ public class WordleController {
 
     private final WordleService wordleService;
     private final WordleStatisticService wordleStatisticService;
-    private String targetWord;
-    private int attempts;
+
+    private static final String SESSION_TARGET_WORD = "wordleTargetWord";
+    private static final String SESSION_ATTEMPTS = "wordleAttempts";
 
     public WordleController(WordleService wordleService, WordleStatisticService wordleStatisticService) {
         this.wordleService = wordleService;
@@ -27,18 +28,16 @@ public class WordleController {
     }
 
     @GetMapping
-    public String wordle(Model model) {
-        targetWord = wordleService.getRandomWord();
-        attempts = 0;
+    public String wordle(Model model, HttpSession session) {
+        startNewGame(session);
         model.addAttribute("message", "새 게임 시작");
         return "wordle";
     }
 
     @PostMapping("/start")
     @ResponseBody
-    public Map<String, String> startGame() {
-        targetWord = wordleService.getRandomWord();
-        attempts = 0;
+    public Map<String, String> startGame(HttpSession session) {
+        startNewGame(session);
         return Map.of("message", "새 게임 시작");
     }
 
@@ -46,6 +45,7 @@ public class WordleController {
     @PostMapping("/guess")
     @ResponseBody
     public Object guess(@RequestBody Map<String, String> payload, HttpSession session) {
+        String targetWord = (String) session.getAttribute(SESSION_TARGET_WORD);
         if (targetWord == null) {
             return Map.of("error", "게임이 시작되지 않았습니다.");
         }
@@ -56,7 +56,7 @@ public class WordleController {
             return Map.of("error", "존재하지 않는 단어입니다.");
         }
 
-        attempts++;
+        int attempts = incrementAttempts(session);
         List<String> result = wordleService.checkGuess(guess, targetWord);
 
         User loginUser = (User) session.getAttribute("loginUser");
@@ -66,8 +66,7 @@ public class WordleController {
             if (loginUser != null) {
                 wordleStatisticService.recordGameResult(loginUser, true);
             }
-            targetWord = null;
-            attempts = 0;
+            resetGame(session);
             return Map.of("result", result, "success", true);
         }
 
@@ -77,8 +76,7 @@ public class WordleController {
                 wordleStatisticService.recordGameResult(loginUser, false);
             }
             String answer = targetWord;
-            targetWord = null;
-            attempts = 0;
+            resetGame(session);
             return Map.of("result", result, "success", false, "answer", answer);
         }
 
@@ -94,5 +92,25 @@ public class WordleController {
             model.addAttribute("myRanking", wordleStatisticService.getRankingSnapshot(loginUser));
         }
         return "wordle-ranking";
+    }
+
+    private void startNewGame(HttpSession session) {
+        session.setAttribute(SESSION_TARGET_WORD, wordleService.getRandomWord());
+        session.setAttribute(SESSION_ATTEMPTS, 0);
+    }
+
+    private int incrementAttempts(HttpSession session) {
+        Integer attempts = (Integer) session.getAttribute(SESSION_ATTEMPTS);
+        if (attempts == null) {
+            attempts = 0;
+        }
+        attempts++;
+        session.setAttribute(SESSION_ATTEMPTS, attempts);
+        return attempts;
+    }
+
+    private void resetGame(HttpSession session) {
+        session.removeAttribute(SESSION_TARGET_WORD);
+        session.removeAttribute(SESSION_ATTEMPTS);
     }
 }

--- a/src/test/java/me/owlsleep/owlab/controller/WordleControllerTest.java
+++ b/src/test/java/me/owlsleep/owlab/controller/WordleControllerTest.java
@@ -1,0 +1,80 @@
+package me.owlsleep.owlab.controller;
+
+import me.owlsleep.owlab.service.WordleService;
+import me.owlsleep.owlab.service.WordleStatisticService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockHttpSession;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(WordleController.class)
+class WordleControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private WordleService wordleService;
+
+    @MockBean
+    private WordleStatisticService wordleStatisticService;
+
+    @Test
+    void gamesAreIsolatedPerSession() throws Exception {
+        when(wordleService.getRandomWord()).thenReturn("APPLE", "BERRY");
+        when(wordleService.exists(anyString())).thenReturn(true);
+        when(wordleService.checkGuess(eq("APPLE"), eq("APPLE"))).thenReturn(List.of("G", "G", "G", "G", "G"));
+        when(wordleService.checkGuess(eq("APPLE"), eq("BERRY"))).thenReturn(List.of("B", "B", "B", "B", "B"));
+        when(wordleService.checkGuess(eq("BERRY"), eq("BERRY"))).thenReturn(List.of("G", "G", "G", "G", "G"));
+
+        MockHttpSession session1 = new MockHttpSession();
+        MockHttpSession session2 = new MockHttpSession();
+
+        mockMvc.perform(post("/wordle/start").session(session1))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.message").value("새 게임 시작"));
+
+        mockMvc.perform(post("/wordle/start").session(session2))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.message").value("새 게임 시작"));
+
+        mockMvc.perform(post("/wordle/guess").session(session1)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"guess\":\"APPLE\"}"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.result[0]").value("G"));
+
+        mockMvc.perform(post("/wordle/guess").session(session1)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"guess\":\"APPLE\"}"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.error").value("게임이 시작되지 않았습니다."));
+
+        mockMvc.perform(post("/wordle/guess").session(session2)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"guess\":\"APPLE\"}"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.result[0]").value("B"))
+                .andExpect(jsonPath("$.success").doesNotExist());
+
+        mockMvc.perform(post("/wordle/guess").session(session2)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"guess\":\"BERRY\"}"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.result[0]").value("G"));
+    }
+}


### PR DESCRIPTION
## Summary
- store Wordle target word and attempts in the HTTP session instead of controller fields
- reset session-scoped state when games end and reuse helpers to start new games
- add a MockMvc test covering concurrent sessions to ensure isolation

## Testing
- ./gradlew test *(fails: missing Java 17 toolchain in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d1577e55f4832889251752f9f108bc